### PR TITLE
Ajustando descrição da quarta imagem do site

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -33,7 +33,7 @@
                         <div class="box_img"><img src="assets/img/foto.jpg" alt="Primeira foto da Pratica" class="size_img"></div>
                         <div class="box_img"><img src="assets/img/img-fabs.jpeg" alt="Segunda foto da Pratica" class="size_img"></div>
                         <div class="box_img"><img src="assets/img/code.jpg" alt="Terceira foto da Pratica" class="size_img"></div>
-                        <div class="box_img"><img src="assets/img/image-04.jpg" alt="Qaurta foto da Pratica" class="size_img"></div>
+                        <div class="box_img"><img src="assets/img/image-04.jpg" alt="Quarta foto da Pratica" class="size_img"></div>
                         <div class="box_img"><img src="assets/img/img.jpg" alt="Quinta foto da Pratica" class="size_img"></div>
                         <div class="box_img"><img src="assets/img/imagem-05.jpg" alt="Sexta foto da Pratica" class="size_img"></div>
                     </div>


### PR DESCRIPTION
A descrição da quarta imagem da galeria de imagens anteriormente estava escrita incorretamente, ajustei a descrição para ficar correta.

<img width="861" height="93" alt="imagem_2025-10-28_164729007" src="https://github.com/user-attachments/assets/0f24aba5-509c-475e-aa18-23bd62ec6739" />

