### PR TITLE
fix: ajustando descrição da quarta imagem do site

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -33,7 +33,7 @@
                         <div class="box_img"><img src="assets/img/foto.jpg" alt="Primeira foto da Pratica" class="size_img"></div>
                         <div class="box_img"><img src="assets/img/img-fabs.jpeg" alt="Segunda foto da Pratica" class="size_img"></div>
                         <div class="box_img"><img src="assets/img/code.jpg" alt="Terceira foto da Pratica" class="size_img"></div>
-                        <div class="box_img"><img src="assets/img/image-04.jpg" alt="Quarta foto da Pratica" class="size_img"></div>
+                        <div class="box_img"><img src="assets/img/image-04.jpg" alt="Quarta foto da Pratica." class="size_img"></div>
                         <div class="box_img"><img src="assets/img/img.jpg" alt="Quinta foto da Pratica" class="size_img"></div>
                         <div class="box_img"><img src="assets/img/imagem-05.jpg" alt="Sexta foto da Pratica" class="size_img"></div>
                     </div>


### PR DESCRIPTION
Ajustando escrita da descrição da quarta imagem do site:

<img width="819" height="85" alt="imagem_2025-10-28_165221730" src="https://github.com/user-attachments/assets/b598dcb4-f86e-4c61-886c-7acc27373dae" />
