### PR TITLE
fix: Verificação de Elementos

### DIFF
--- a/scripts/galeria.js
+++ b/scripts/galeria.js
@@ -4,6 +4,11 @@ const janela_img = document.querySelector('#img_janela')
 const btn = document.querySelector('#btn_close')
 let endere = ""
 
+if (!janela || !janela_img || !btn) {
+    console.error('Elementos não encontrados')
+    return
+}
+
 for(let i=0 ; i < img.length ; i++){
     img[i].addEventListener('click', () => {
        endere = img[i].getAttribute("src")


### PR DESCRIPTION
close #16 Quando o JavaScript tenta manipular elementos do DOM que não existem na página, o código para de executar e gera erros no console, quebrando toda a funcionalidade. A verificação preventiva garante que o código só executa se todos os elementos essenciais existirem, prevenindo quebras na aplicação e proporcionando uma experiência mais robusta.